### PR TITLE
Optimizations

### DIFF
--- a/whatwg_url.py
+++ b/whatwg_url.py
@@ -774,7 +774,10 @@ class UrlParser(object):
         elif self.base.cannot_be_base_url and c == "#":
             self.url._scheme = self.base.scheme
             self.url._path = self.base._path[:]
-            self.url._query = list(self.base.query) if self.base.query is not None else None
+            if self.base.query is None:
+                self.url._query = None
+            else:
+                self.url._query = list(self.base.query)
             self.url._fragment = []
             self.url.cannot_be_base_url = True
             self._state = PARSER_STATE_FRAGMENT
@@ -816,7 +819,10 @@ class UrlParser(object):
             self.url._hostname = self.base.hostname
             self.url._port = self.base.port
             self.url._path = self.base._path[:]
-            self.url._query = self.url._query = list(self.base.query) if self.base.query is not None else None
+            if self.base.query is None:
+                self.url._query = None
+            else:
+                self.url._query = list(self.base.query)
 
         elif c == "/":
             self._state = PARSER_STATE_RELATIVE_SLASH
@@ -837,7 +843,10 @@ class UrlParser(object):
             self.url._hostname = self.base.hostname
             self.url._port = self.base.port
             self.url._path = self.base._path[:]
-            self.url._query = self.url._query = list(self.base.query) if self.base.query is not None else None
+            if self.base.query is None:
+                self.url._query = None
+            else:
+                self.url._query = list(self.base.query)
             self.url._fragment = []
 
             self._state = PARSER_STATE_FRAGMENT
@@ -1040,7 +1049,10 @@ class UrlParser(object):
             if c == "":
                 self.url._hostname = self.base.hostname
                 self.url._path = self.base._path[:]
-                self.url._query = self.url._query = list(self.base.query) if self.base.query is not None else None
+                if self.base.query is None:
+                    self.url._query = None
+                else:
+                    self.url._query = list(self.base.query)
 
             elif c == "?":
                 self.url._hostname = self.base.hostname
@@ -1052,7 +1064,10 @@ class UrlParser(object):
             elif c == "#":
                 self.url._hostname = self.base.hostname
                 self.url._path = self.base._path[:]
-                self.url._query = self.url._query = list(self.base.query) if self.base.query is not None else None
+                if self.base.query is None:
+                    self.url._query = None
+                else:
+                    self.url._query = list(self.base.query)
                 self.url._fragment = []
 
                 self._state = PARSER_STATE_FRAGMENT


### PR DESCRIPTION
Currently this library runs slow on large URLs. This PR includes two optimizations to help:

### 'remaining' string construction

The library spends a lot of time doing this in the main loop to create the 'remaining' string:

```py
data[self._pointer + 1 :]
```

However it never needs more than the first two characters after the current pointer. By limiting the new string to only the next two characters, run time drops ~65%.

### large query/fragment parsing

When parsing the query and fragment parts of a URL the final string is reconstructed for every character checked. By using a list to hold parsing progress instead of a string, it can validate them much faster.
